### PR TITLE
Added new Opt-in on the HashIdOptions 

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="AspNetCore.Hashids Versions">
-    <AspNetCoreHashids>1.1.1$(VersionSuffix)</AspNetCoreHashids>
+    <AspNetCoreHashids>1.2.0$(VersionSuffix)</AspNetCoreHashids>
   </PropertyGroup>
 
   <PropertyGroup Label="Package Dependencies">

--- a/src/AspNetCore.Hashids/Options/HashidsOptions.cs
+++ b/src/AspNetCore.Hashids/Options/HashidsOptions.cs
@@ -18,5 +18,10 @@
         /// Steps (Default "cfhistuCFHISTU")
         /// </summary>
         public string Steps { get; set; } = HashidsNet.Hashids.DEFAULT_SEPS;
+
+        /// <summary>
+        /// Specify if non hashed-ids are allowed on the request. Default is true.
+        /// </summary>
+        public bool AcceptNonHashedIds { get; set; } = true;
     }
 }

--- a/test/AspNetCore.Hashids.Tests/Seedwork/ServerFixture.cs
+++ b/test/AspNetCore.Hashids.Tests/Seedwork/ServerFixture.cs
@@ -45,6 +45,7 @@ namespace AspNetCore.Hashids.Tests.Seedwork
                 {
                     setup.Salt = "&`r&?mKW7}shDja%$l|bBS)DlA-WHz+-OP:8D#*PK|r{*_2Haxm(5Xj>l67s)5+h";
                     setup.MinHashLength = 8;
+                    setup.AcceptNonHashedIds = false; // does not allow to send regular integeres instead hasids
                 })
                 .AddControllers();
         }

--- a/test/AspNetCore.Hashids.Tests/aspnetcore_hasids_should.cs
+++ b/test/AspNetCore.Hashids.Tests/aspnetcore_hasids_should.cs
@@ -95,6 +95,25 @@ namespace AspNetCore.Hashids.Tests
 
             response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
         }
+
+        [Fact]
+        public async Task doesn_not_allow_send_integer_instead_hashid_if_configuration_reject_it()
+        {
+            var dto = new CustomerDto
+            {
+                Id = 1,
+                FirstName = "Test",
+                LastName = "Test"
+            };
+
+            var response = await fixture
+                .TestServer
+                .CreateRequest($"api/customers")
+                .WithJsonBody(dto)
+                .PostAsync();
+
+            response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        }
     }
 
     [Route("api/customers")]


### PR DESCRIPTION
This add a new OptIn on HashIdsOptions to configure if default integers are allowed or not on deserialization.

```csharp
public class HashidsOptions
    {
        ...

        /// <summary>
        /// Specify if non hashed-ids are allowed on the request. Default is true.
        /// </summary>
        public bool AcceptNonHashedIds { get; set; } = true;
    }
```